### PR TITLE
Increase container's shared memory size for usage by pytorch dataloader

### DIFF
--- a/jupyter/PW/run.sh
+++ b/jupyter/PW/run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 docker build -f prod.Dockerfile -t pw_nvidia_jupyter .
-docker run -d --gpus all -p 8888:8888 -v /home/quantum/sip:/home/jovyan/work -e JUPYTER_ENABLE_LAB=yes -e NVIDIA_DRIVER_CAPABILITIES=all --restart always --name pw_nvidia_jupyter_1 pw_nvidia_jupyter:latest
+docker run -d --shm-size=1g --gpus all -p 8888:8888 -v /home/quantum/sip:/home/jovyan/work -e JUPYTER_ENABLE_LAB=yes -e NVIDIA_DRIVER_CAPABILITIES=all --restart always --name pw_nvidia_jupyter_1 pw_nvidia_jupyter:latest


### PR DESCRIPTION
Error message:
> RuntimeError: DataLoader worker (pid 2066958) is killed by signal: Bus error. It is possible that dataloader's workers are out of shared memory. Please try to raise your shared memory limit.

Increased shared memory size and tested locally.