### PR TITLE
14802. Fix bug when running multiple notebooks would fail

### DIFF
--- a/data/notebooks/pw/croptype_pipeline.ipynb
+++ b/data/notebooks/pw/croptype_pipeline.ipynb
@@ -28,7 +28,7 @@
     "import matplotlib.pyplot as plt\n",
     "from datetime import datetime\n",
     "\n",
-    "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"1\"\n",
+    "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0\"\n",
     "sys.path.append(\"code/\")\n",
     "from code.prediction_pipeline.run import run"
    ]
@@ -65,7 +65,7 @@
    "outputs": [],
    "source": [
     "CONFIG_PATH = f\"/home/{USER}/work/notebooks/pw/code/prediction_pipeline/config.yml\"\n",
-    "prediction_file = run(CONFIG_PATH, aoi_filename, start_date, end_date)\n",
+    "prediction_file = run(CONFIG_PATH, aoi_filename, start_date, end_date, REQUEST_ID)\n",
     "os.remove(aoi_filename)"
    ]
   },


### PR DESCRIPTION
1. Use REQUEST_ID when running pipeline as an additional identifier to prevent problems when running multiple notebooks (code on the SIP server is updated)
2. Use GPU 0 instead of 1 due to the latest changes to resource allocation.