### PR TITLE
14886. Use newer version of ESA SNAP to avoid an error with orbit files

### DIFF
--- a/jupyter/PW/esa_snap_update.sh
+++ b/jupyter/PW/esa_snap_update.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+snap --nosplash --nogui --modules --update-all 2>&1 | while read -r line;
+do
+    echo "$line"
+    [ "$line" = "updates=0" ] && sleep 2 && pkill -TERM -f "snap/jre/bin/java"
+done

--- a/jupyter/PW/prod.Dockerfile
+++ b/jupyter/PW/prod.Dockerfile
@@ -17,6 +17,10 @@ RUN wget -q http://step.esa.int/downloads/8.0/installers/esa-snap_sentinel_unix_
     rm esa-snap_sentinel_unix_8_0.sh && \
     ln -s /opt/snap/bin/gpt /usr/bin/gpt
 
+# Update ESA SNAP to the latest version
+COPY esa_snap_update.sh /tmp/
+RUN /tmp/esa_snap_update.sh
+
 # Add data required for Sentinel-1 preprocessing
 RUN mkdir -p /home/jovyan/.snap/auxdata/dem/ && \
     ln -s /home/jovyan/work/notebooks/pw/data/SRTM\ 3Sec /home/jovyan/.snap/auxdata/dem/


### PR DESCRIPTION
[A forum thread](https://forum.step.esa.int/t/orbit-file-timeout-march-2021/28621/70) about the problem that occurred around a week ago.
Solution: use updated version of SNAP

Command for updating SNAP was taken from [here](https://senbox.atlassian.net/wiki/spaces/SNAP/pages/30539785/Update+SNAP+from+the+command+line).

